### PR TITLE
Migrate to 0.9 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,20 @@ which has been modified to use [Rerun](https://github.com/rerun-io/rerun) for vi
 
 ## Installation
 
+### Conda
 Assuming [conda](https://docs.conda.io/en/latest/miniconda.html) is installed on your system. Dependancies can be installed with
 
 ```
 conda env create -f environment.yml
+```
+
+### virtualenv + pip
+Make sure `nvcc` is available (11.7 assumed and tested here, feel free to try other versions). Create a virtualenv and install dependencies.
+```
+python3 -m venv env
+source env/bin/activate
+pip install torch==1.13.1 torchvision==0.14.1 # need to manually beforehand, because pytorch3d doesn't specify install dependencies properly
+pip install -r requirements.txt
 ```
 
 ## Quick Rerun visualziation

--- a/demo.py
+++ b/demo.py
@@ -228,6 +228,10 @@ def point_cloud_to_depth_map(point_cloud, img_shape):
 
 
 def main(args):
+    # NOTE projection is done with RDF camera without extrinsics, hence Y will be down
+    #  for upright images
+    rr.log("input_points", rr.ViewCoordinates.RIGHT_HAND_Y_DOWN, timeless=True)
+    rr.log("predicted_points", rr.ViewCoordinates.RIGHT_HAND_Y_DOWN, timeless=True)
 
     model = mcc_model.get_mcc_model(
         occupancy_weight=1.0,

--- a/demo.py
+++ b/demo.py
@@ -83,7 +83,7 @@ def log_points(occupancy, xyz, color, threshold=0.1):
         "predicted_points",
         rr.Points3D(
             positions=points[good_points].cpu(),
-            colors=features[good_points].numpy(force=True)
+            colors=features[good_points].cpu()
         )
     )
 
@@ -269,8 +269,8 @@ def main(args):
         rr.log(
             "input-image/bbox-for-seg",
             rr.Boxes2D(
-                mins=bbox[:2],
-                sizes=bbox[2:] - bbox[:2],
+                array=bbox,
+                array_format=rr.Box2DFormat.XYXY,
                 colors=(255, 0, 0),
             )
         )
@@ -307,7 +307,7 @@ def main(args):
 
     rr.log(
         "input_points",
-        rr.Points3D(positions=seen_xyz[mask], colors=seen_rgb[mask].numpy())
+        rr.Points3D(positions=seen_xyz[mask], colors=seen_rgb[mask])
     )
 
     seen_xyz = normalize(seen_xyz)

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
     - h5py
     - omegaconf
     - submitit
-    - rerun-sdk
+    - rerun-sdk>=0.9.0
     - numpy==1.23
     - -e git+https://github.com/facebookresearch/segment-anything.git#egg=segment-anything
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,4 @@ h5py
 omegaconf
 submitit
 numpy==1.23
--f https://build.rerun.io/commit/b814745/wheels 
-rerun-sdk==0.9.0a4
+rerun-sdk>=0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+pytorch3d @ git+https://github.com/facebookresearch/pytorch3d.git@v0.7.4
+segment_anything @ git+https://github.com/facebookresearch/segment-anything
+fvcore
+iopath
+timm==0.6.7
+opencv-python
+matplotlib
+plotly
+h5py
+omegaconf
+submitit
+numpy==1.23
+-f https://build.rerun.io/commit/b814745/wheels 
+rerun-sdk==0.9.0a4


### PR DESCRIPTION
Generally works fine. https://github.com/rerun-io/rerun/issues/3712 gives a poor default view however.

Also added view coordinates that work well for close-to-upright images, and install instructions that do not require Conda.